### PR TITLE
Add GET /api/v1/stock/all endpoint

### DIFF
--- a/server/src/main/java/com/easytrade/server/ServerApplication.java
+++ b/server/src/main/java/com/easytrade/server/ServerApplication.java
@@ -2,8 +2,10 @@ package com.easytrade.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);

--- a/server/src/main/java/com/easytrade/server/controller/StockMarketController.java
+++ b/server/src/main/java/com/easytrade/server/controller/StockMarketController.java
@@ -97,7 +97,10 @@ public class StockMarketController {
     }
 
 
-
-
+    @GetMapping("/all")
+    @Transactional(readOnly = true)
+    public ResponseEntity<?> getAllStocks() {
+        return ResponseEntity.ok(stockMarketService.getAllStocks());
+    }
     // get info {id}
 }

--- a/server/src/main/java/com/easytrade/server/dto/AllStocksResponse.java
+++ b/server/src/main/java/com/easytrade/server/dto/AllStocksResponse.java
@@ -1,0 +1,73 @@
+package com.easytrade.server.dto;
+
+import com.easytrade.server.model.Stock;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AllStocksResponse {
+    List<Stock> stocks;
+}
+
+/**
+ * Example response body:
+ * {
+ *     "stocks": [
+ *         {
+ *             "symbol": "AAPL",
+ *             "company": "Apple Inc",
+ *             "currentOpen": 158.86,
+ *             "changeInPercent": 0.83
+ *         },
+ *         {
+ *             "symbol": "GOOG",
+ *             "company": "Google",
+ *             "currentOpen": 105.74,
+ *             "changeInPercent": -0.19
+ *         },
+ *         {
+ *             "symbol": "GOOGL",
+ *             "company": "todo",
+ *             "currentOpen": 104.99,
+ *             "changeInPercent": -0.15
+ *         },
+ *         {
+ *             "symbol": "META",
+ *             "company": "todo",
+ *             "currentOpen": 205.18,
+ *             "changeInPercent": 0.85
+ *         },
+ *         {
+ *             "symbol": "MSFT",
+ *             "company": "todo",
+ *             "currentOpen": 277.24,
+ *             "changeInPercent": 1.05
+ *         },
+ *         {
+ *             "symbol": "NVDA",
+ *             "company": "todo",
+ *             "currentOpen": 270.31,
+ *             "changeInPercent": -1.52
+ *         },
+ *         {
+ *             "symbol": "PCAR",
+ *             "company": "todo",
+ *             "currentOpen": 69.26,
+ *             "changeInPercent": 0.13
+ *         },
+ *         {
+ *             "symbol": "TSLA",
+ *             "company": "todo",
+ *             "currentOpen": 191.65,
+ *             "changeInPercent": -0.94
+ *         }
+ *     ]
+ * }
+ * */

--- a/server/src/main/java/com/easytrade/server/dto/StockListRequest.java
+++ b/server/src/main/java/com/easytrade/server/dto/StockListRequest.java
@@ -1,0 +1,4 @@
+package com.easytrade.server.dto;
+
+public class StockListRequest {
+}

--- a/server/src/main/java/com/easytrade/server/model/PriceType.java
+++ b/server/src/main/java/com/easytrade/server/model/PriceType.java
@@ -1,6 +1,0 @@
-package com.easytrade.server.model;
-
-public enum PriceType {
-    OPEN,
-    CLOSE,
-}

--- a/server/src/main/java/com/easytrade/server/model/Stock.java
+++ b/server/src/main/java/com/easytrade/server/model/Stock.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Date;
 
 @Data
@@ -19,8 +21,7 @@ public class Stock {
     @Id
     @Column(name="symbol")
     private String symbol;
-
     private String company;
-
-    private Date timeOfLastUpdate;
+    private BigDecimal currentOpen;
+    private BigDecimal changeInPercent;
 }

--- a/server/src/main/java/com/easytrade/server/model/StockData.java
+++ b/server/src/main/java/com/easytrade/server/model/StockData.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.time.LocalDate;
 
 /**
@@ -28,16 +29,14 @@ public class StockData {
     private Stock stock;
 
     @Column(name="date")
-    private LocalDate date;
-
+    private Date date;
     private BigDecimal ask;
     private BigDecimal bid;
+    private BigDecimal open;
+    private BigDecimal close;
     private BigDecimal price;
-    private BigDecimal previousClose;
-    private BigDecimal earningsPerShare;
-    private BigDecimal priceToEarningsRatio;
 
 
-    @Enumerated(EnumType.STRING)
-    private PriceType priceType;
+//    private BigDecimal earningsPerShare;
+//    private BigDecimal priceToEarningsRatio;
 }

--- a/server/src/main/java/com/easytrade/server/repository/StockDataRepository.java
+++ b/server/src/main/java/com/easytrade/server/repository/StockDataRepository.java
@@ -1,9 +1,11 @@
 package com.easytrade.server.repository;
 
 import com.easytrade.server.model.StockData;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +13,9 @@ import java.util.Optional;
 public interface StockDataRepository extends CrudRepository<StockData, Integer> {
     @Query("SELECT p FROM StockData p WHERE p.stock.symbol = :symbol AND p.date = :date")
     Optional<StockData> getPriceBySymbolAndDate(String symbol, LocalDate date);
+
+    @Query("SELECT p FROM StockData p WHERE (p.date >= :start AND p.date <= :end)")
+    List<StockData> getAllSymbolsBetweenDates(Date start, Date end);
 
     @Query("SELECT p FROM StockData p WHERE p.stock.symbol = :symbol AND (p.date >= :start AND p.date <= :end)")
     List<StockData> getPricesBySymbolBetweenDates(String symbol, LocalDate start, LocalDate end);

--- a/server/src/main/java/com/easytrade/server/service/StockDataRetriever.java
+++ b/server/src/main/java/com/easytrade/server/service/StockDataRetriever.java
@@ -1,0 +1,95 @@
+package com.easytrade.server.service;
+
+import com.easytrade.server.config.EasyTradeProperties;
+import com.easytrade.server.model.Stock;
+import com.easytrade.server.model.StockData;
+import com.easytrade.server.repository.StockDataRepository;
+import com.easytrade.server.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import yahoofinance.YahooFinance;
+import yahoofinance.quotes.stock.StockQuote;
+
+import java.io.IOException;
+import java.math.RoundingMode;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class StockDataRetriever {
+    private final StockDataRepository stockDataRepository;
+    private final StockRepository stockRepository;
+    private final EasyTradeProperties easyTradeProperties;
+
+    @Scheduled(fixedRate=864_000_000) // 24 hours (in millis)
+    public void retrieveStockData() {
+        String[] symbols = easyTradeProperties.getSymbols();
+        Map<String, yahoofinance.Stock> yahooFinanceStockMap;
+        try {
+            yahooFinanceStockMap = YahooFinance.get(symbols);
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+            return;
+        }
+
+        List<StockData> dataFromToday = yahooFinanceStockMap.entrySet().stream()
+                        .map((entry) -> {
+                            String symbol = entry.getKey();
+                            yahoofinance.Stock yahooFinanceStock = entry.getValue();
+                            StockQuote stockQuote = yahooFinanceStock.getQuote();
+
+                            // TODO: This fallback potentially saves data twice.
+                            Stock stock = stockRepository.getStockBySymbol(symbol).orElse(
+                                    stockRepository.save(Stock.builder()
+                                            .symbol(symbol)
+                                            .company("todo")
+                                            .currentOpen(stockQuote.getOpen())
+                                            .changeInPercent(stockQuote.getChangeInPercent())
+                                            .build()));
+
+                            // If the stock was already present, we still want to update its data.
+                            stock.setCurrentOpen(stockQuote.getOpen());
+                            stock.setChangeInPercent(stockQuote.getChangeInPercent());
+                            stockRepository.save(stock);
+
+                            return StockData.builder()
+                                    .stock(stock)
+                                    .ask(stockQuote.getAsk())
+                                    .bid(stockQuote.getBid())
+                                    .open(stockQuote.getOpen())
+                                    .price(stockQuote.getPrice())
+                                    .date(Date.valueOf(LocalDate.now()))
+                                    .build();
+                        }).toList();
+
+        // Save all data points from today
+        stockDataRepository.saveAll(dataFromToday);
+
+        yahooFinanceStockMap.forEach((symbol, stock) -> {
+            System.out.printf("Stock: '%s'\n" +
+                            "Data: '%s'\n" +
+                            "Quote: '%s'\n" +
+                            "Stats: '%s'\n" +
+                            "Dividend: '%s'\n" +
+                            "Short Ratio: '%s'\n" +
+                            "Open: '%s'\n" +
+                            "Testing percentage thing: '%s'\n" +
+                            "\n",
+                    symbol,
+                    stock.toString(),
+                    stock.getQuote().toString(),
+                    stock.getStats().toString(),
+                    stock.getDividend().toString(),
+                    stock.getStats().getShortRatio(),
+                    stock.getQuote().getOpen(),
+                    stock.getQuote().getChangeInPercent()
+//                    (stock.getQuote().getOpen().divide(stock.getQuote().getPreviousClose(), RoundingMode.HALF_UP))
+        );
+        });
+    }
+}

--- a/server/src/main/java/com/easytrade/server/service/StockMarketService.java
+++ b/server/src/main/java/com/easytrade/server/service/StockMarketService.java
@@ -1,13 +1,11 @@
 package com.easytrade.server.service;
 
-import com.easytrade.server.dto.BuyStockRequest;
-import com.easytrade.server.dto.BuyStockResponse;
-import com.easytrade.server.dto.GetStockRequest;
-import com.easytrade.server.dto.GetStockResponse;
+import com.easytrade.server.dto.*;
 import com.easytrade.server.exception.InsufficientFundsException;
 import com.easytrade.server.exception.InvalidQuantityException;
 import com.easytrade.server.exception.NonexistentUserException;
 import com.easytrade.server.exception.UnknownTickerSymbolException;
+import com.easytrade.server.model.Stock;
 import com.easytrade.server.model.StockData;
 import com.easytrade.server.model.User;
 import com.easytrade.server.repository.StockDataRepository;
@@ -20,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -70,8 +69,10 @@ public class StockMarketService {
         return BuyStockResponse.builder().message("Success").build();
     }
 
-//    public StockListResponse getAllStocks(GetAllStocksRequest request) {
-//    }
+    public AllStocksResponse getAllStocks() {
+        List<Stock> stocks = (List<Stock>) stockRepository.findAll();
+        return AllStocksResponse.builder().stocks(stocks).build();
+    }
 
 
     public GetStockResponse getStock(GetStockRequest request) throws UnknownTickerSymbolException {


### PR DESCRIPTION
Notable changes:
+ Added `StockDataRetriever` class. Quick and dirty solution to ensuring our database has cached at least today's stock data.
+ Added the endpoint for `GET /api/v1/stock/all`, which will return a list of `Stock` objects. The response body has the following shape:
```json
{
    "stocks": [
        {
            "symbol": "AAPL",
            "company": "todo",
            "currentOpen": 158.86,
            "changeInPercent": 0.83
        }
    ]
}
```